### PR TITLE
Feature/swagger API문서 자동화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ dependencies {
 	// Valid
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/comment/controller/CommentController.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/comment/controller/CommentController.java
@@ -3,6 +3,8 @@ package com.ll.gooHaeYu.domain.jobPost.comment.controller;
 import com.ll.gooHaeYu.domain.jobPost.comment.dto.CommentDto;
 import com.ll.gooHaeYu.domain.jobPost.comment.dto.CommentForm;
 import com.ll.gooHaeYu.domain.jobPost.comment.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 import java.util.List;
 
+@Tag(name = "Comment", description = "구인공고 댓글 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/post-comment/{postId}")
@@ -19,12 +22,14 @@ public class CommentController {
     private final CommentService commentService;
 
     @GetMapping
+    @Operation(summary = "해당 공고에 달린 댓글 목록")
     public ResponseEntity<List<CommentDto>> findByPostId(@PathVariable Long postId) {
 
         return ResponseEntity.ok(commentService.findByPostId(postId));
     }
 
     @PostMapping("/comment")
+    @Operation(summary = "댓글 작성")
     public ResponseEntity<String> write (Authentication authentication,
                                          @PathVariable Long postId,
                                          @Valid @RequestBody CommentForm.Register form){
@@ -34,6 +39,7 @@ public class CommentController {
     }
 
     @PutMapping("/comment/{commentId}")
+    @Operation(summary = "댓글 수정")
     public ResponseEntity<Void> modify (Authentication authentication,
                                           @PathVariable Long postId,
                                           @PathVariable Long commentId,
@@ -44,6 +50,7 @@ public class CommentController {
     }
 
     @DeleteMapping("/comment/{commentId}")
+    @Operation(summary = "댓글 삭제")
     public ResponseEntity delete (Authentication authentication,
                                   @PathVariable Long postId,
                                   @PathVariable Long commentId) {

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/controller/JobPostController.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/controller/JobPostController.java
@@ -3,6 +3,8 @@ package com.ll.gooHaeYu.domain.jobPost.jobPost.controller;
 import com.ll.gooHaeYu.domain.jobPost.jobPost.dto.JobPostDto;
 import com.ll.gooHaeYu.domain.jobPost.jobPost.dto.JobPostForm;
 import com.ll.gooHaeYu.domain.jobPost.jobPost.service.JobPostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 import java.util.List;
 
+@Tag(name = "JobPost", description = "구인공고 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/job-posts")
@@ -19,6 +22,7 @@ public class JobPostController {
     private final JobPostService jobPostService;
 
     @PostMapping
+    @Operation(summary = "구인공고 작성")
     public ResponseEntity<String> writePost(Authentication authentication,
                                             @Valid @RequestBody JobPostForm.Register form) {
         Long jobPostId = jobPostService.writePost(authentication.getName(), form);
@@ -27,6 +31,7 @@ public class JobPostController {
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "구인공고 수정")
     public ResponseEntity<Void> modifyPost(Authentication authentication,
                                              @PathVariable(name = "id") Long id,
                                              @Valid @RequestBody JobPostForm.Modify form) {
@@ -36,6 +41,7 @@ public class JobPostController {
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "구인공고 삭제")
     public ResponseEntity<Void> deletePost(Authentication authentication,
                                             @PathVariable(name = "id") Long id) {
         jobPostService.deletePost(authentication.getName(), id);
@@ -44,11 +50,13 @@ public class JobPostController {
     }
 
     @GetMapping
+    @Operation(summary = "구인공고 글 목록 가져오기")
     public ResponseEntity<List<JobPostDto>> findAllPost() {
         return ResponseEntity.ok(jobPostService.findAll());
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "구인공고 단건 조회")
     public ResponseEntity<JobPostDto> showDetailPost(@PathVariable(name = "id") Long id) {
         return  ResponseEntity.ok(jobPostService.findById(id));
     }

--- a/src/main/java/com/ll/gooHaeYu/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/member/member/controller/MemberController.java
@@ -3,6 +3,9 @@ package com.ll.gooHaeYu.domain.member.member.controller;
 import com.ll.gooHaeYu.domain.member.member.dto.AddMemberForm;
 import com.ll.gooHaeYu.domain.member.member.dto.LoginMemberRequest;
 import com.ll.gooHaeYu.domain.member.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,11 +13,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.validation.Valid;
-
 import java.net.URI;
 
-
+@Tag(name = "Member", description = "회원 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
@@ -23,12 +24,14 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/join")
+    @Operation(summary = "회원가입")
     public ResponseEntity<String> join(@RequestBody @Valid AddMemberForm request) {
         Long userId = memberService.join(request);
         return ResponseEntity.created(URI.create("/api/member/join" + userId)).build();
     }
 
     @PostMapping("/login")
+    @Operation(summary = "로그인")
     public ResponseEntity<String> login(@RequestBody @Valid LoginMemberRequest request) {
         String token = memberService.login(request);
         return ResponseEntity.ok(token);

--- a/src/main/java/com/ll/gooHaeYu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ll/gooHaeYu/global/config/SecurityConfig.java
@@ -5,15 +5,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
@@ -43,9 +41,11 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests -> {
-                    requests.requestMatchers("/api/member/login", "/api/member/join").permitAll();
-                    requests.requestMatchers(HttpMethod.GET,"/api/post-comment/{id:\\d+}", "/api/job-posts/{id:\\d+}", "/api/job-posts").permitAll();
-                    requests.anyRequest().authenticated();
+                    requests
+                            .requestMatchers("/api/member/login", "/api/member/join").permitAll()
+                            .requestMatchers(HttpMethod.GET, "/api/job-posts/{id:\\d+}", "/api/job-posts").permitAll()
+                            .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                            .anyRequest().authenticated();
                 })
                 .sessionManagement(
                         sessionManagement ->

--- a/src/main/java/com/ll/gooHaeYu/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ll/gooHaeYu/global/config/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package com.ll.gooHaeYu.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+@OpenAPIDefinition(
+        info = @Info(title = "구해유",
+                description = "구해유 API 명세서",
+                version = "v1"))
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization");
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .security(Arrays.asList(securityRequirement));
+    }
+}


### PR DESCRIPTION
---
## 모든 API 요청에 JWT 토큰이 자동으로 Authorization 헤더에 포함되도록 설정하는 방법

<br>

http://localhost:8090/swagger-ui/index.html 에 접속

<br>

join, login을 통해서 토큰을 얻은 후,

<br>


![Authorize](https://github.com/Techit7-11/gooHaeYu/assets/76129297/60b209e8-d3c4-4092-b18b-b834e1c74d8d)

<br>


화면 오른쪽 상단에 해당 아이콘을 눌러서 Value: 에 복사 해놓은 토큰 값을 붙여넣고, Authorize 를 누르면 

<br>

<img src="https://github.com/Techit7-11/gooHaeYu/assets/76129297/3af8302a-fb4d-4f65-ac9e-45b203ad132b" width="400" height="170">

<br><br>

Swagger에서 보내는 모든 API 요청에 JWT 토큰이 자동으로 Authorization 헤더에 포함되어 전송됩니다.

<br>

### * refresh token 도입시에는 설정 변경 필요
<br><br>

---
### API 문서에 설명 추가

1. `@RestController` 위에 작성
 `@Tag`(name = "JobPost", description = "구인공고 API")

2. 각 controller의 메서드에서 메서드명 바로 위에 작성
 `@Operation`(summary = "구인공고 작성", description = "구인공고 생성 및 URI 반환.")    // description은 옵션
<br>